### PR TITLE
Spanish home page. Spanish nav items

### DIFF
--- a/NuSurvey.MVC/Controllers/HomeController.cs
+++ b/NuSurvey.MVC/Controllers/HomeController.cs
@@ -24,6 +24,15 @@ namespace NuSurvey.MVC.Controllers
             return View(viewModel);
         }
 
+        public ActionResult Spanish(bool parent = true)
+        {
+            var viewModel = HomeViewModel.Create(CurrentUser.IsInRole(RoleNames.Admin), CurrentUser.IsInRole(RoleNames.User), CurrentUser.IsInRole(RoleNames.ProgramDirector));
+
+            ViewBag.OnlyParent = true;
+
+            return View(viewModel);
+        }
+
         /// <summary>
         /// #2
         /// </summary>

--- a/NuSurvey.MVC/NuSurvey.MVC.csproj
+++ b/NuSurvey.MVC/NuSurvey.MVC.csproj
@@ -507,6 +507,7 @@
     <Content Include="Views\SurveyResponse\PublicSurveys.cshtml" />
     <Content Include="Views\SurveyResponse\Results.cshtml" />
     <Content Include="Views\SurveyResponse\StartSurvey.cshtml" />
+    <Content Include="Views\Home\Spanish.cshtml" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="App_Data\" />

--- a/NuSurvey.MVC/Views/Home/Spanish.cshtml
+++ b/NuSurvey.MVC/Views/Home/Spanish.cshtml
@@ -1,0 +1,43 @@
+﻿@model NuSurvey.MVC.Controllers.HomeController.HomeViewModel
+
+@{
+    ViewBag.Title = "Healthy Kids - Home Page";
+    Layout = "~/Views/Shared/_HomeLayout.cshtml";
+    ViewBag.IsSpanish = true;
+}
+
+@section AdditionalScripts
+{
+    <script type="text/javascript" src='@Url.Content("~/Scripts/DataTables/jquery.dataTables.min.js")'></script>
+    <script type="text/javascript" src='@Url.Content("~/Scripts/jquery.bt.min.js")'></script>
+
+    <script type="text/javascript">
+        $(document).ready(function () {
+            $('.balloon').bt({ positions: 'bottom' });
+        });
+    </script>
+
+}
+
+<span class="SpecialFont">
+    <div id="parents">
+        <div class="container-center">
+            <div id="parents-left">
+                <h2>PARENTS</h2>
+                <p>Want to keep your child healthy?</p>
+                <p>Take the survey and have goals created just for you and your child!</p>
+                <img src="@Url.Image("arrow.png")" alt="Select a Survey" />
+            </div>
+
+            <div id="parents-right">
+                <a href='@Url.Action("FindAndStartSurvey", "SurveyResponse", new { shortname = "HKS"})'><img src="@Url.Image("hk-thumb.png")" alt="Healthy Kids Survey" /></a>
+                <a href='@Url.Action("FindAndStartSurvey", "SurveyResponse", new { shortname = "MCMTS" })'><img src="@Url.Image("mcmt-thumb.png")" alt="My Child At Mealtime Survey" /></a>
+
+            </div>
+            <br style="clear:both">
+        </div> <!--- END main MLR 121313 --->
+
+    </div>
+    
+</span>
+

--- a/NuSurvey.MVC/Views/Shared/_Navigation.cshtml
+++ b/NuSurvey.MVC/Views/Shared/_Navigation.cshtml
@@ -1,13 +1,23 @@
 ﻿<div id="nav">
-<ul class="navigation">
-    <li>@Html.ActionLink("Home", "Index", "Home")</li>
-    <li>@Html.ActionLink("Parents", "Index", "Home",new { parent = true}, new{})</li>
-    <li>@Html.ActionLink("Educators", "Index", "Educator")</li>
-     <li>@Html.ActionLink("Directors", "Index", "ProgramDirector")</li>
-    @if(User.IsInRole("NSAdmin")){
-        <li>@Html.ActionLink("Admin", "Administration", "Home")</li>
-    }
+    <ul class="navigation">
+        @if (ViewBag.IsSpanish != null && (bool) ViewBag.IsSpanish)
+        {
+            <li>@Html.ActionLink("SSHome", "Spanish", "Home")</li>
+            <li>@Html.ActionLink("SSParents", "Spanish", "Home", new {parent = true}, new {})</li>
+            <li>@Html.ActionLink("Not Spanish?", "Index", "Home")</li>
+        }
+        else
+        {
+            <li>@Html.ActionLink("Home", "Index", "Home")</li>
+            <li>@Html.ActionLink("Parents", "Index", "Home", new {parent = true}, new {})</li>
+            <li>@Html.ActionLink("Educators", "Index", "Educator")</li>
+            <li>@Html.ActionLink("Directors", "Index", "ProgramDirector")</li>
+        }
 
-</ul>
+        @if (User.IsInRole("NSAdmin"))
+        {
+            <li>@Html.ActionLink("Admin", "Administration", "Home")</li>
+        }
 
-    </div>
+    </ul>
+</div>

--- a/NuSurvey.MVC/Views/Shared/_Navigation.cshtml
+++ b/NuSurvey.MVC/Views/Shared/_Navigation.cshtml
@@ -10,6 +10,7 @@
         {
             <li>@Html.ActionLink("Home", "Index", "Home")</li>
             <li>@Html.ActionLink("Parents", "Index", "Home", new {parent = true}, new {})</li>
+            <li>@Html.ActionLink("Not English?", "Spanish", "Home")</li>
             <li>@Html.ActionLink("Educators", "Index", "Educator")</li>
             <li>@Html.ActionLink("Directors", "Index", "ProgramDirector")</li>
         }

--- a/NuSurvey.MVC/Views/SurveyResponse/AnswerNext.cshtml
+++ b/NuSurvey.MVC/Views/SurveyResponse/AnswerNext.cshtml
@@ -6,6 +6,10 @@
     ViewBag.Title = "Next Question";
     Layout = "~/Views/Shared/_LayoutNew.cshtml";
     ViewBag.questionDisplay = string.Format("display-{0}-question", Model.Survey.ShortName.ToLower().Trim());
+    if (Model.Survey.ShortName.IsSpanish())
+    {
+        ViewBag.IsSpanish = true;
+    }
 }
 
 

--- a/NuSurvey.MVC/Views/SurveyResponse/StartSurvey.cshtml
+++ b/NuSurvey.MVC/Views/SurveyResponse/StartSurvey.cshtml
@@ -1,9 +1,14 @@
-﻿@model NuSurvey.MVC.Controllers.SingleAnswerSurveyResponseViewModel
+﻿@using NuSurvey.MVC.Helpers
+@model NuSurvey.MVC.Controllers.SingleAnswerSurveyResponseViewModel
 
 
 @{
     ViewBag.Title = "Start Survey";
     Layout = "~/Views/Shared/_LayoutNew.cshtml";
+    if (Model.Survey.ShortName.IsSpanish())
+    {
+        ViewBag.IsSpanish = true;
+    }
 }
 
 @section AdditionalScripts{


### PR DESCRIPTION
For the Spanish section there are a few things that we would like. Please let me know if this will be too difficult.
1. Create a Spanish version of this page (http://healthykids.ucdavis.edu/?parent=True).
2. Add a button to the current homepage to the page created in item #1
3. Create a Spanish version of the navigation menu
4. Place Spanish navigation menu on the page in item #1 and the two Spanish surveys.
